### PR TITLE
Spatial transcriptomics

### DIFF
--- a/FijiPyLib/src/main/resources/ROITools.py
+++ b/FijiPyLib/src/main/resources/ROITools.py
@@ -643,7 +643,9 @@ def subtractROI(TotalRegion,Region2Remove,img,growth=0, fit = True):
     OUTPUT Fiji ROI storing the cropped region of interest
 
     AR Jan 2022
-    AP Jun 2022
+    AP Jun 2022: Create boolean parameter to condition rectangular fit
+    for spatial transcriptomic enlargement code written in Semi Auto
+    Segmentation plugin.
     '''
 
     # Make sure that the image is displayed

--- a/FijiPyPlugins/src/main/resources/scripts/Plugins/Quantify_Fields_of_View/Semi_Auto_Cell_Labeling_.py
+++ b/FijiPyPlugins/src/main/resources/scripts/Plugins/Quantify_Fields_of_View/Semi_Auto_Cell_Labeling_.py
@@ -376,16 +376,16 @@ if(unitIncrease != 0):
         # Merge the others
         other = ROITools.combineROIs(others)
         # Get the intersection of ROIs using the intersecting function
-        AND = ROITools.getIntersectingROI([nucROI, other])
+        intersection = ROITools.getIntersectingROI([nucROI, other])
         # If there is overlap, then proceed to remove it
-        if AND.getLength() > 0:
+        if intersection.getLength() > 0:
             # subtract AND from nucROI
-            croppedROI = subtractROI(nucROI, AND, fit = False)
+            croppedROI = subtractROI(nucROI, intersection, fit = False)
             # Combine resulting ROI with original nuclear segmentation
             nucROIs[i] = ROITools.combineROIs([croppedROI, psgROIs[i]])
 
     del psgROIs, croppedROI
-    del AND, other, others, nucROI
+    del intersection, other, others, nucROI
 
 ########################################################################
 ####################### LABEL CELLS BY CELL TYPE #######################


### PR DESCRIPTION
Added the series of changes discussed with AR and AP 5/20/2022. Changes include new libraries imported and allowing the user to input an ROI dilation in order to analyze spatial transcriptomic data. The program iterates through the nuclear segmentations generated by the user earlier in the script, expands by the given expansion factor, and removes the overlaps. Missed an off by one error and added to this merge.